### PR TITLE
Update documentation for better use clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ How to use
     ```
     let g:fixmyjs_rc_path = 'path/to/.rc'
     ```
-if you don't specify the path, it will try to find the `.rc` from `$HOME/.rc`, `$HOME/.vim/.rc`
+if you don't specify the path, it will try to find the `.rc` from `$HOME/.rc`, `$HOME/.vim/.rc` or the root of your project directory.
+Note that this plugin considers the directory where your .git directory is located as the root of your project directory. This can cause
+some confusion when you have a valid `.eslintrc` config file but have not initialised git in the project directory. The plugin will fail
+to execute citing `Can not find a valid config file: .eslintrc from your project root path or global paths`.
+
 
 
 4. For convenience it is recommended that you assign a key for this, like so:


### PR DESCRIPTION
I faced a bug in using this today when I was trying to do a quick test with react. I initialized eslint config as per usual without having initializing a git repository. I noticed that the plugin wasn't working stating "Can not find a valid config file: .eslintrc from your project root path or global paths" even though there was a clearly one. I remedied this by initializing a git repository. I also remember from a previous issue I submitted that you stated this plugin will first look at the root project folder for a config file. I just wanted future users of this plugin to be aware of the issue so they do not have to go through what I did which caused some confusion. 