### PR TITLE
Add support for non-root level `.eslintrc`, `node_modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ to execute citing `Can not find a valid config file...`.
     let g:fixmyjs_executable = 'path/to/eslint'
     ```
 
+7. If you want to do an upwards search for a configuration file based on the current working directory, you can specify:
+
+   ```
+   " search for config file upwards recursively, falling back to other configs
+   let g:fixmyjs_rc_local = 1
+   ```
+
 Sort import
 ----------
 

--- a/plugin/fixmyjs.vim
+++ b/plugin/fixmyjs.vim
@@ -46,6 +46,10 @@ if !exists('g:fixmyjs_rc_path')
   let g:fixmyjs_rc_path = ''
 endif
 
+if !exists('g:fixmyjs_rc_local')
+  let g:fixmyjs_rc_local = 0
+endif
+
 if !exists('g:fixmyjs_legacy_jshint')
     let g:fixmyjs_legacy_jshint = 0
 endif
@@ -74,6 +78,33 @@ endif
 " using the list of possible paths
 func! s:find_rc_path()
   let s:rc_file_found = 0
+
+  " If specified, try to find the nearest configuration file based on the
+  " current file
+  if g:fixmyjs_rc_local
+    if type(g:fixmyjs_rc_filename) == type([])
+      for l:rc_filename in g:fixmyjs_rc_filename
+        let l:rc_filename_found = findfile(l:rc_filename, '.;')
+        let l:full_path = l:rc_filename_found
+        if filereadable(l:full_path)
+          let g:fixmyjs_rc_path = l:full_path
+          let s:rc_file_found = 1
+          break
+        endif
+      endfor
+    else
+      let l:rc_filename_found = findfile(g:fixmyjs_rc_filename, '.;')
+      let l:full_path = l:rc_filename_found
+      if filereadable(l:full_path)
+        let g:fixmyjs_rc_path = l:full_path
+        let s:rc_file_found = 1
+      endif
+    endif
+    if s:rc_file_found
+      return s:rc_file_found
+    endif
+  endif
+
   if type(g:fixmyjs_rc_filename) == type([])
     for l:possible_path in s:possible_paths
       for l:rc_filename in g:fixmyjs_rc_filename

--- a/plugin/fixmyjs.vim
+++ b/plugin/fixmyjs.vim
@@ -145,9 +145,21 @@ let s:supportedFileTypes = ['js']
 
 "% Helper functions and variables
 
-if exists('g:fixmyjs_use_local') && g:fixmyjs_use_local
-    let g:fixmyjs_executable = s:project_root_path . '/node_modules/.bin/' . g:fixmyjs_engine
-endif
+func! s:find_executable()
+  if exists('g:fixmyjs_use_local') && g:fixmyjs_use_local
+    let g:fixmyjs_node_modules = finddir('node_modules', '.;')
+    if !empty(g:fixmyjs_node_modules)
+      let g:fixmyjs_executable = getcwd() . '/' . g:fixmyjs_node_modules . '/.bin/' . g:fixmyjs_engine
+    endif
+    if !filereadable(g:fixmyjs_executable)
+      let g:fixmyjs_executable = s:project_root_path . '/node_modules/.bin/' . g:fixmyjs_engine
+    endif
+    if !filereadable(g:fixmyjs_executable)
+      " fall back to system one if we can't find anything
+      let g:fixmyjs_executable = g:fixmyjs_engine
+    endif
+  endif
+endfun
 
 func! Fixmyjs(...)
   call s:find_rc_path()
@@ -159,6 +171,8 @@ func! Fixmyjs(...)
       return 1
     endif
   endif
+
+  call s:find_executable()
 
   let winview=winsaveview()
   let path = expand("%:p")


### PR DESCRIPTION
This PR is to add support for two new features:
1. Searching for the nearest `.eslintrc` (or whatever else configuration file as defined) of the file being edited
    - Turned off by default, enabled by `let g:fixmyjs_rc_local = 1`
    - This allows for projects that have multiple `.eslintrc` configuration files to be respected
    - Tested with a mono-repo that had multiple `.eslintrc` files in it
2. Search for the nearest `node_modules/.bin` of the file being edited
    - This allows for projects that have multiple `node_modules` locally to use the one most likely to be used by the edited file
    - This resolves issues such as differences in versions of `eslint` b/t subdirectories, as well as differences in `eslint` plugin requirements
    - Additionally, this attempts to fall back to the system level if it can't find anything

Any feedback or additional testing would be greatly appreciated, cheers!